### PR TITLE
chore(deps): update to use Quarkus JOSDK extension 3.0.1

### DIFF
--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/controller/controller.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/controller/controller.go
@@ -48,37 +48,28 @@ func (f *Controller) SetTemplateDefaults() error {
 	return nil
 }
 
-// TODO: pass in the name of the operator i.e. replace Memcached
 const controllerTemplate = `package {{ .Package }};
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.javaoperatorsdk.operator.api.*;
-import io.javaoperatorsdk.operator.api.Context;
-import io.javaoperatorsdk.operator.processing.event.EventSourceManager;
+import io.javaoperatorsdk.operator.api.reconciler.Context;
+import io.javaoperatorsdk.operator.api.reconciler.Reconciler;
+import io.javaoperatorsdk.operator.api.reconciler.UpdateControl;
 
-@Controller
-public class {{ .ClassName }}Controller implements ResourceController<{{ .ClassName }}> {
+public class {{ .ClassName }}Reconciler implements Reconciler<{{ .ClassName }}> { 
+  private final KubernetesClient client;
 
-    private final KubernetesClient client;
+  public {{ .ClassName }}Reconciler(KubernetesClient client) {
+    this.client = client;
+  }
 
-    public {{ .ClassName }}Controller(KubernetesClient client) {
-        this.client = client;
-    }
+  // TODO Fill in the rest of the reconciler
 
-    // TODO Fill in the rest of the controller
+  @Override
+  public UpdateControl<{{ .ClassName }}> reconcile({{ .ClassName }} resource, Context context) {
+    // TODO: fill in logic
 
-    @Override
-    public void init(EventSourceManager eventSourceManager) {
-        // TODO: fill in init
-    }
-
-    @Override
-    public UpdateControl<{{ .ClassName }}> createOrUpdateResource(
-        {{ .ClassName }} resource, Context<{{ .ClassName }}> context) {
-        // TODO: fill in logic
-
-        return UpdateControl.noUpdate();
-    }
+    return UpdateControl.noUpdate();
+  }
 }
 
 `

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/model/model.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/model/model.go
@@ -49,7 +49,6 @@ func (f *Model) SetTemplateDefaults() error {
 	return nil
 }
 
-// TODO: pass in the name of the operator i.e. replace Memcached
 const modelTemplate = `package {{ .Package }};
 
 {{if .Resource.API.Namespaced}}import io.fabric8.kubernetes.api.model.Namespaced;{{end}}

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -57,24 +57,16 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <fabric8-client.version>5.8.0</fabric8-client.version>
-    <quarkus-sdk.version>2.0.0</quarkus-sdk.version>
-    <quarkus.version>2.4.0.Final</quarkus.version>
+    <quarkus-sdk.version>3.0.1</quarkus-sdk.version>
+    <quarkus.version>2.6.2.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>
     <dependencies>
       <dependency>
-        <groupId>io.fabric8</groupId>
-        <artifactId>kubernetes-client-bom</artifactId>
-        <version>${fabric8-client.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-      <dependency>
-        <groupId>io.quarkus</groupId>
-        <artifactId>quarkus-bom</artifactId>
-        <version>${quarkus.version}</version>
+        <groupId>io.quarkiverse.operatorsdk</groupId>
+        <artifactId>quarkus-operator-sdk-bom</artifactId>
+        <version>${quarkus-sdk.version}</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
Since the extension now uses a BOM, we don't need to track the JOSDK
and fabric8 versions separately. We still need to provide the Quarkus
version even though it's provided in the BOM because we need it for the
maven plugin and there is no way to retrieve the version from the BOM…
