### PR TITLE
bug for command addition in Makefile - Bug 2099603

### DIFF
--- a/pkg/quarkus/v1alpha/api.go
+++ b/pkg/quarkus/v1alpha/api.go
@@ -109,7 +109,7 @@ func (p *createAPISubcommand) Scaffold(fs machinery.Filesystem) error {
 			projectName = strings.ToLower(filepath.Base(dir))
 		}
 
-		makefileBytes = append(makefileBytes, []byte(fmt.Sprintf(makefileBundleVarFragment, p.resource.Plural, p.resource.QualifiedGroup(), p.resource.Version, projectName))...)
+		makefileBytes = append(makefileBytes, []byte(fmt.Sprintf(makefileBundleVarFragment, p.resource.Plural, p.resource.QualifiedGroup(), p.resource.Version))...)
 
 		makefileBytes = append([]byte(fmt.Sprintf(makefileBundleImageFragement, p.config.GetDomain(), projectName)), makefileBytes...)
 
@@ -217,7 +217,7 @@ const (
 .PHONY: bundle
 bundle:  ## Generate bundle manifests and metadata, then validate generated files.
 ## marker
-	cat target/kubernetes/%[1]s.%[2]s-%[3]s.yml target/kubernetes/kubernetes.yml | operator-sdk generate bundle -q --overwrite --version 0.1.1 --default-channel=stable --channels=stable --package=%[4]s
+	cat target/kubernetes/%[1]s.%[2]s-%[3]s.yml target/kubernetes/kubernetes.yml | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
 	operator-sdk bundle validate ./bundle
 	
 .PHONY: bundle-build
@@ -233,7 +233,35 @@ bundle-push: ## Push the bundle image.
 const (
 	makefileBundleImageFragement = `
 VERSION ?= 0.0.1
+
+# CHANNELS define the bundle channels used in the bundle.
+# Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
+# To re-generate a bundle for other specific channels without changing the standard setup, you can:
+# - use the CHANNELS as arg of the bundle target (e.g make bundle CHANNELS=candidate,fast,stable)
+# - use environment variables to overwrite this value (e.g export CHANNELS="candidate,fast,stable")
+ifneq ($(origin CHANNELS), undefined)
+BUNDLE_CHANNELS := --channels=$(CHANNELS)
+endif
+
+# DEFAULT_CHANNEL defines the default channel used in the bundle.
+# Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
+# To re-generate a bundle for any other default channel without changing the default setup, you can:
+# - use the DEFAULT_CHANNEL as arg of the bundle target (e.g make bundle DEFAULT_CHANNEL=stable)
+# - use environment variables to overwrite this value (e.g export DEFAULT_CHANNEL="stable")
+ifneq ($(origin DEFAULT_CHANNEL), undefined)
+BUNDLE_DEFAULT_CHANNEL := --default-channel=$(DEFAULT_CHANNEL)
+endif
+BUNDLE_METADATA_OPTS ?= $(BUNDLE_CHANNELS) $(BUNDLE_DEFAULT_CHANNEL)
+
+# IMAGE_TAG_BASE defines the docker.io namespace and part of the image name for remote images.
+# This variable is used to construct full image tags for bundle and catalog images.
+#
+# For example, running 'make bundle-build bundle-push catalog-build catalog-push' will build and push both
+# %[1]s/%[2]s-bundle:$VERSION and %[1]s/%[2]s-catalog:$VERSION.
 IMAGE_TAG_BASE ?= %[1]s/%[2]s
+
+# BUNDLE_IMG defines the image:tag used for the bundle.
+# You can use it as an arg. (E.g make bundle-build BUNDLE_IMG=<some-registry>/<project-name-bundle>:<tag>)
 BUNDLE_IMG ?= $(IMAGE_TAG_BASE)-bundle:v$(VERSION)
 `
 )


### PR DESCRIPTION
Description of problem:
Bundle version is overwrite by a fixed version (0.1.1) in Makefile for java type operator.

Version-Release number of selected component (if applicable):
operator-sdk version: "v1.20.0-ocp", commit: "4db4731ae75f2cccae951dd7ed98484662179c55", kubernetes version: "v1.24.1", go version: "go1.18.3", GOOS: "linux", GOARCH: "amd64"

How reproducible:
always

Steps to Reproduce:
1.$operator-sdk init --plugins quarkus --domain example.com --project-name memcached-quarkus-operator
2.$operator-sdk create api --plugins quarkus --group cache --version v1 --kind Memcached

Actual results:
$cat Makefile
##@Bundle
.PHONY: bundle
bundle:  ## Generate bundle manifests and metadata, then validate generated files.
## marker
	cat target/kubernetes/memcacheds.cache.example.com-v1.yml target/kubernetes/kubernetes.yml | operator-sdk generate bundle -q --overwrite --version 0.1.1 --default-channel=stable --channels=stable --package=memcached-quarkus-operator
	operator-sdk bundle validate ./bundle

Expected results:
##@Bundle
.PHONY: bundle
bundle:  ## Generate bundle manifests and metadata, then validate generated files.
## marker
	cat target/kubernetes/memcacheds.cache.example.com-v1.yml target/kubernetes/kubernetes.yml | operator-sdk generate bundle -q --overwrite --version $(VERSION) $(BUNDLE_METADATA_OPTS)
	operator-sdk bundle validate ./bundle

Additional info:
