### PR TITLE
feat: update to use JOSDK 3.1 and latest Quarkus extension

### DIFF
--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/applicationproperties.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/applicationproperties.go
@@ -49,6 +49,4 @@ const ApplicationPropertiesTemplate = `quarkus.container-image.build=true
 quarkus.container-image.name={{ .ProjectName }}-operator
 # set to true to automatically apply CRDs to the cluster when they get regenerated
 quarkus.operator-sdk.crd.apply=false
-# set to true to automatically generate CSV from your code
-quarkus.operator-sdk.generate-csv=false
 `

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -77,9 +77,10 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
       <groupId>io.quarkiverse.operatorsdk</groupId>
       <artifactId>quarkus-operator-sdk</artifactId>
     </dependency>
+    <!-- Needed to generate OLM bundle. If you're not interested in this, you can remove this dependency -->
     <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>
-      <artifactId>quarkus-operator-sdk-csv-generator</artifactId>
+      <artifactId>quarkus-operator-sdk-bundle-generator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -57,7 +57,7 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>3.1.0</quarkus-sdk.version>
+    <quarkus-sdk.version>4.0.0</quarkus-sdk.version>
     <quarkus.version>2.7.5.Final</quarkus.version>
   </properties>
 

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -57,7 +57,7 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>3.0.7</quarkus-sdk.version>
+    <quarkus-sdk.version>3.1.0</quarkus-sdk.version>
     <quarkus.version>2.7.5.Final</quarkus.version>
   </properties>
 

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -58,7 +58,7 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus-sdk.version>4.0.0</quarkus-sdk.version>
-    <quarkus.version>2.7.5.Final</quarkus.version>
+    <quarkus.version>2.11.2.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -37,7 +37,7 @@
     </dependency>
     <dependency>
       <groupId>io.quarkiverse.operatorsdk</groupId>
-      <artifactId>quarkus-operator-sdk-csv-generator</artifactId>
+      <artifactId>quarkus-operator-sdk-bundle-generator</artifactId>
     </dependency>
     <dependency>
       <groupId>io.quarkus</groupId>

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>3.0.7</quarkus-sdk.version>
+    <quarkus-sdk.version>3.1.0</quarkus-sdk.version>
     <quarkus.version>2.7.5.Final</quarkus.version>
   </properties>
 

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>3.1.0</quarkus-sdk.version>
+    <quarkus-sdk.version>4.0.0</quarkus-sdk.version>
     <quarkus.version>2.7.5.Final</quarkus.version>
   </properties>
 

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -16,7 +16,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus-sdk.version>4.0.0</quarkus-sdk.version>
-    <quarkus.version>2.7.5.Final</quarkus.version>
+    <quarkus.version>2.11.2.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>


### PR DESCRIPTION
- bump java operator sdk version to latest 3.1.0
- updated version
- fix: remove now obsolete property
- fix: update wrong dependency
- chore(deps): update Quarkus version
- chore(deps): update Quarkus version
- fix: update outdated dependency, add comment
