### PR TITLE
chore: upgrade to Quarkus 3.2.0 and QOSDK 6.2.1

### DIFF
--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/applicationproperties.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/applicationproperties.go
@@ -47,6 +47,6 @@ func (f *ApplicationPropertiesFile) SetTemplateDefaults() error {
 const ApplicationPropertiesTemplate = `quarkus.container-image.build=true
 #quarkus.container-image.group=
 quarkus.container-image.name={{ .ProjectName }}-operator
-# set to true to automatically apply CRDs to the cluster when they get regenerated
-quarkus.operator-sdk.crd.apply=false
+# set to false to prevent CRDs from being applied to the cluster automatically (only applies to dev mode, CRD applying is disabled in prod)
+# quarkus.operator-sdk.crd.apply=false
 `

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -57,7 +57,7 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>6.2.0</quarkus-sdk.version>
+    <quarkus-sdk.version>6.2.1</quarkus-sdk.version>
     <quarkus.version>3.2.0.Final</quarkus.version>
   </properties>
 

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -53,8 +53,8 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
   <properties>
     <compiler-plugin.version>3.10.1</compiler-plugin.version>
     <maven.compiler.parameters>true</maven.compiler.parameters>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.source>17</maven.compiler.source>
+    <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <quarkus-sdk.version>6.0.0</quarkus-sdk.version>

--- a/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
+++ b/pkg/quarkus/v1alpha/scaffolds/internal/templates/pomxml.go
@@ -57,8 +57,8 @@ const pomxmlTemplate = `<?xml version="1.0" encoding="UTF-8"?>
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>6.0.0</quarkus-sdk.version>
-    <quarkus.version>3.0.0.Final</quarkus.version>
+    <quarkus-sdk.version>6.2.0</quarkus-sdk.version>
+    <quarkus.version>3.2.0.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -15,8 +15,8 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>6.0.0</quarkus-sdk.version>
-    <quarkus.version>3.0.0.Final</quarkus.version>
+    <quarkus-sdk.version>6.2.0</quarkus-sdk.version>
+    <quarkus.version>3.2.0.Final</quarkus.version>
   </properties>
 
   <dependencyManagement>

--- a/testdata/quarkus/memcached-quarkus-operator/pom.xml
+++ b/testdata/quarkus/memcached-quarkus-operator/pom.xml
@@ -15,7 +15,7 @@
     <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <quarkus-sdk.version>6.2.0</quarkus-sdk.version>
+    <quarkus-sdk.version>6.2.1</quarkus-sdk.version>
     <quarkus.version>3.2.0.Final</quarkus.version>
   </properties>
 

--- a/testdata/quarkus/memcached-quarkus-operator/src/main/resources/application.properties
+++ b/testdata/quarkus/memcached-quarkus-operator/src/main/resources/application.properties
@@ -3,5 +3,5 @@ quarkus.container-image.build=true
 quarkus.container-image.name=memcached-quarkus-operator-operator
 # set to true to automatically apply CRDs to the cluster when they get regenerated
 quarkus.operator-sdk.crd.apply=false
-# set to true to automatically generate CSV from your code
-quarkus.operator-sdk.generate-csv=false
+# set to true to automatically generate OLM bundle from your code
+quarkus.operator-sdk.bundle.enabled=false


### PR DESCRIPTION
- fix: clarify apply CRD usage
- feat: move to java 17 by default
- chore: upgrade Quarkus to 3.2.0 and QOSDK to 6.2.0
