### PR TITLE
fix: add Quarkus plugin deprecation

### DIFF
--- a/pkg/quarkus/v1beta/plugin.go
+++ b/pkg/quarkus/v1beta/plugin.go
@@ -66,3 +66,10 @@ func (p Plugin) GetCreateAPISubcommand() plugin.CreateAPISubcommand { return &p.
 
 // // GetEditSubcommand will return the subcommand which is responsible for editing the scaffold of the project
 // func (p Plugin) GetEditSubcommand() plugin.EditSubcommand { return &p.editSubcommand }
+
+func (p Plugin) DeprecationWarning() string {
+	return "This plugin is deprecated and will be eventually removed." +
+		" It is recommended that you bootstrap your Quarkus-based operator with" +
+		" the provided Quarkus tools as described in the bootstraping instructions -" +
+		" https://github.com/quarkiverse/quarkus-operator-sdk?tab=readme-ov-file#bootstrapping-a-project."
+}


### PR DESCRIPTION
This will fix https://github.com/operator-framework/operator-sdk/issues/6645.

We should deprecate the plugin nevertheless before we remove it from operator-sdk.

But it will be up to @metacosm, I think I can keep this running for a while. I'm still not sure how much people are used to operator-sdk workflow vs using custom tools to bootstrap their operators.