### PR TITLE
Update github actions to use node 20

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,10 @@
 
 version: 2
 updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
   - package-ecosystem: "" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,10 +7,10 @@ jobs:
     name: lint
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - run: make lint

--- a/.github/workflows/test-unit.yml
+++ b/.github/workflows/test-unit.yml
@@ -7,10 +7,10 @@ jobs:
     name: unit
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: actions/setup-go@v3
+      - uses: actions/setup-go@v5
         with:
           go-version-file: "go.mod"
       - run: make test


### PR DESCRIPTION
* Update github actions to latest
* Configure dependabot to check for newer versions of actions